### PR TITLE
Add broken link checker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,29 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+
+      - name: Build
+        run: |
+          npm install
+          npm run build
+
+      - name: Check broken links
+        run: set -o pipefail; npm run linkchecker 2>/dev/null | grep "Getting links from\|BROKEN"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "config": {
-    "linkchecker": "blc -ro --filter-level 0 --exclude libp2p.io --exclude twitter.com --exclude swarm.ethereum.org --exclude gateway.ethswarm.org --exclude discord.gg --exclude github.com --exclude reddit.com --exclude medium.com --exclude wikipedia.org --exclude etherscan.io --exclude awesome.re --exclude swarm.eth --exclude localhost:1633 --exclude localhost:9090 --exclude localhost:1635 --exclude 192.168.0.1 --exclude 127.0.0.1"
+    "linkchecker": "blc -ro --filter-level 0 --exclude swarm.ethereum.org --exclude gateway.ethswarm.org --exclude discord.gg --exclude etherscan.io --exclude awesome.re --exclude swarm.eth --exclude localhost:1633 --exclude localhost:9090 --exclude localhost:1635 --exclude 192.168.0.1 --exclude 127.0.0.1"
   },
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,19 @@
   "name": "bee-docs",
   "version": "0.0.0",
   "private": true,
+  "config": {
+    "linkchecker": "blc -ro --filter-level 0 --exclude libp2p.io --exclude twitter.com --exclude swarm.ethereum.org --exclude gateway.ethswarm.org --exclude discord.gg --exclude github.com --exclude reddit.com --exclude medium.com --exclude wikipedia.org --exclude etherscan.io --exclude awesome.re --exclude swarm.eth --exclude localhost:1633 --exclude localhost:9090 --exclude localhost:1635 --exclude 192.168.0.1 --exclude 127.0.0.1"
+  },
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
-    "serve": "docusaurus serve"
+    "serve": "docusaurus serve",
+    "linkchecker": "start-server-and-test serve :3000 linkchecker:local",
+    "linkchecker:local": "$npm_package_config_linkchecker http://localhost:3000/docs",
+    "linkchecker:prod": "$npm_package_config_linkchecker https://docs.ethswarm.org/docs/"
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.71",
@@ -35,5 +41,9 @@
   "engines": {
     "node": ">=14.0.0",
     "npm": ">=6.0.0"
+  },
+  "devDependencies": {
+    "broken-link-checker": "^0.7.8",
+    "start-server-and-test": "^1.12.3"
   }
 }


### PR DESCRIPTION
This PR adds a tool to check for broken links and a build workflow that uses it at every merge into the master.

I excluded some links that may not be desirable to be tested, but if needed, the tool's parameters are easy to customize.