### PR TITLE
Update keep-your-data-alive.md

### DIFF
--- a/docs/access-the-swarm/keep-your-data-alive.md
+++ b/docs/access-the-swarm/keep-your-data-alive.md
@@ -10,7 +10,7 @@ The swarm comprises the sum total of all storage space provided by all of our no
 To start up your node, you will already have provided your node with gETH for gas and gBZZ which was transferred into your chequebook when your node was initialised and will be used to interact with other nodes using the *SWAP* protocol. In order to access more funds to buy batches of stamps, your wallet must be funded with gBZZ. The easiest way to acheive this is to withdrawal funds from your chequebook.
 
 ```bash
-curl -XPOST "http://localhost:1635/chequebook/withdraw/?amount=1000"
+curl -XPOST "http://localhost:1635/chequebook/withdraw?amount=1000"
 ```
 
 ## Purchase a Batch of Stamps


### PR DESCRIPTION
Slash at the end of URL causes a 404 error when trying to use withdraw endpoint