### PR TITLE
Update ":::warn" to ":::warning"

### DIFF
--- a/docs/access-the-swarm/host-your-website.md
+++ b/docs/access-the-swarm/host-your-website.md
@@ -35,7 +35,7 @@ Once you have restarted your node, you should be able to see the Swarm homepage 
 Use the `resolver-options` flag to point the bee resolver to any ENS compatible smart-contract on any EVM compatible chain
 :::
 
-:::warn
+:::warning
 Make sure you trust the gateway you are interacting with! To ensure that you are retrieving the correct content, run your own ENS resolver and Bee node.
 :::
 


### PR DESCRIPTION
Second time's a charm 😅 

Updated `:::warn` to `:::warning` so that it actually formats on the "How to host your website" page. You can [see on the docs website](https://docs.ethswarm.org/docs/access-the-swarm/host-your-website#enable-ens-on-your-node) that the text shows up as `:::warn` rather than the formatted box:


![2021-06-22 03_48_33-Host Your Website on Swarm _ Swarm Bee Client](https://user-images.githubusercontent.com/304269/122946715-9754fc00-d347-11eb-8025-0548525d21a1.png)

A fix for this was previously attempted in #201 but after looking at other files, I realize it was because the docs expect "warning"