### PR TITLE
chore: add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .docusaurus
+package-lock.json
 node_modules
 .DS_Store
 build


### PR DESCRIPTION
i'm no node expert, but i think this file should be in gitignore.