### PR TITLE
Stamp purchases are also on port 1635

### DIFF
--- a/docs/access-the-swarm/keep-your-data-alive.md
+++ b/docs/access-the-swarm/keep-your-data-alive.md
@@ -48,7 +48,7 @@ When you purchase a batch of stamps, you agree to burn BZZ. Although your 'balan
 :::
 
 ```bash
-curl -s -XPOST http://localhost:1633/stamps/10000000/20
+curl -s -XPOST http://localhost:1635/stamps/10000000/20
 ```
 
 :::info


### PR DESCRIPTION
Since this is a security-sensitive call, spending the node's funds.