### PR TITLE
Change 'tree build' to 'tree my_website'

### DIFF
--- a/docs/access-the-swarm/upload-a-directory.md
+++ b/docs/access-the-swarm/upload-a-directory.md
@@ -23,7 +23,7 @@ GZIP compression is not supported in the current version of Bee, so make sure no
 First, use the `tar` command line utility to create an archive containing all the files of your directory. If uploading a website, we must take care to ensure that the `index.html` file is at the root of the directory tree.
 
 ```bash
-tree build
+tree my_website
 > 
 my_website
 ├── assets


### PR DESCRIPTION
The command is `tree build` but the directory shown in the output is "my_website". The "my_website" directory is also later used when zipping the directory. I assume this was meant to be `tree my_website`.