### PR TITLE
fix: mainnet network id

### DIFF
--- a/docs/working-with-bee/configuration.md
+++ b/docs/working-with-bee/configuration.md
@@ -96,7 +96,7 @@ gateway-mode: false
 help: false
 mainnet: true
 nat-addr: ""
-network-id: "10"
+network-id: "1"
 p2p-addr: :1634
 p2p-ws-enable: false
 password: ""


### PR DESCRIPTION
`mainnet` is true by default but network ID has an incorrect value, this PR fixes that by setting the network ID to "1".