### PR TITLE
fix: update arch in docs for rpi install

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -52,8 +52,8 @@ sudo dpkg -i bee_1.8.2_amd64.deb
 ##### ARMv7
 
 ```bash
-wget https://github.com/ethersphere/bee/releases/download/v1.8.2/bee_1.8.2_armv7.deb
-sudo dpkg -i bee_1.8.2_armv7.deb
+wget https://github.com/ethersphere/bee/releases/download/v1.8.2/bee_1.8.2_armhf.deb
+sudo dpkg -i bee_1.8.2_armhf.deb
 ```
 
 ##### ARM64

--- a/docs/installation/rasp-bee-ry-pi.md
+++ b/docs/installation/rasp-bee-ry-pi.md
@@ -68,8 +68,8 @@ Raspberry Pi [https://docs.ethswarm.org](https://docs.ethswarm.org).
 Click `Install > Bee Clef` and scroll down to find the installation commands for Bee Clef **ARM (Raspberry Pi) ARMv7**. These should look something like:
 
 ```sh
-wget https://github.com/ethersphere/bee-clef/releases/download/v0.12.0/bee-clef_0.12.0_armv7.deb
-sudo dpkg -i bee-clef_0.12.0_armv7.deb
+wget https://github.com/ethersphere/bee-clef/releases/download/v0.13.1/bee-clef_0.13.1_armhf.deb
+sudo dpkg -i bee-clef_0.13.1_armhf.deb
 ```
 
 Click `Copy` on the right hand side of the box containing the
@@ -81,11 +81,11 @@ character.
 You should see some output from the `wget` command which is a Linux utility this is used to download the correct Bee Clef 'package' from Github, where the development of the Bee utilities takes place.
 
 ```bash
-bee-clef_0.12.0_armv7.deb.1           100%[===================================================================>]   9.99M  8.21MB/s    in 1.2s
+bee-clef_0.13.1_armhf.deb.1           100%[===================================================================>]   9.99M  8.21MB/s    in 1.2s
 
-2021-05-15 17:34:02 (8.21 MB/s) - ‘bee-clef_0.12.0_armv7.deb’ saved [10473282/10473282]
+2021-05-15 17:34:02 (8.21 MB/s) - ‘bee-clef_0.13.1_armhf.deb’ saved [10473282/10473282]
 
-pi@raspberrypi:~ $ sudo dpkg -i bee-clef_0.12.0_armv7.deb
+pi@raspberrypi:~ $ sudo dpkg -i bee-clef_0.13.1_armhf.deb
 ```
 
 The other command will be left in your terminal, this uses the `dpkg` utility, the Debian Package Manager to install Bee Clef. Package Managers are used to conveniently install software on Linux systems.
@@ -93,10 +93,10 @@ The other command will be left in your terminal, this uses the `dpkg` utility, t
 Press enter to start the installation process. All being well, you will see some output like this:
 
 ```
-pi@raspberrypi:~ $ sudo dpkg -i bee-clef_0.12.0_armv7.deb
+pi@raspberrypi:~ $ sudo dpkg -i bee-clef_0.13.1_armhf.deb
 Selecting previously unselected package bee-clef.
 (Reading database ... 98610 files and directories currently installed.)
-Preparing to unpack bee-clef_0.12.0_armv7.deb ...
+Preparing to unpack bee-clef_0.13.1_armhf.deb ...
 Unpacking bee-clef (0.12.0) ...
 Setting up bee-clef (0.12.0) ...
 Created symlink /etc/systemd/system/multi-user.target.wants/bee-clef.service → /lib/systemd/system/bee-clef.service.
@@ -167,8 +167,8 @@ Your output should looks something like this:
 
 ```bash
 -rw-r--r--  1 pi   pi       3523 Mar  4 22:47 .bashrc
--rw-r--r--  1 pi   pi   10787806 Mar 23 08:18 bee_1.8.2_armv7.deb
--rw-r--r--  1 pi   pi   10473282 Feb 24 18:00 bee-clef_0.12.0_armv7.deb
+-rw-r--r--  1 pi   pi   10787806 Mar 23 08:18 bee_1.8.2_armhf.deb
+-rw-r--r--  1 pi   pi   10473282 Feb 24 18:00 bee-clef_0.13.1_armhf.deb
 drwxr-xr-x  2 pi   pi       4096 Mar  4 22:57 Bookshelf
 ```
 
@@ -180,7 +180,7 @@ Now, let's use the `rm` program to remove the clutter and delete the
 `.deb` files we no longer need.
 
 ```bash
-rm bee_1.8.2_armv7.deb
+rm bee_1.8.2_armhf.deb
 ```
 
 The `rm` program gives no output, so let's check it's dissapeared by
@@ -194,7 +194,7 @@ ls -la | grep "bee"
 ```
 
 ```bash
--rw-r--r--  1 pi   pi   10473282 Feb 24 18:00 bee-clef_0.12.0_armv7.deb
+-rw-r--r--  1 pi   pi   10473282 Feb 24 18:00 bee-clef_0.13.1_armhf.deb
 ```
 
 Success! The Bee package file is deleted! Note at the command line


### PR DESCRIPTION
Fixes https://github.com/ethersphere/bee-docs/issues/298

Update arch debian packages files names intructions from armv7 to armhf for arm and rpi