### PR TITLE
Contract addresses

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,15 +44,15 @@ We recommend you run your own [XDAI Node using Nethermind](https://www.xdaichain
   - and set it to `http://localhost:8545`
   - after that sudo systemctl restart bee
 
-### How to export private keys from the node with bee-clef installed
+### How to export private keys from the node with Bee Clef installed
 
-If you are running Bee together with the Bee-Clef, you can type in the command line `bee-clef-keys` and that will store the .JSON file into your home folder and copy the password in your clipboard.
+If you are running Bee together with the Bee Clef, you can type in the command line `bee-clef-keys` and that will store the .JSON file into your home folder and copy the password in your clipboard.
 
-### I have bee-clef installed but I can't export private keys.
+### I have Bee Clef installed but I can't export private keys.
 
-It happens quite a lot that bee-clef is installed, but getting the address from bee-clef-keys does not yield the same output as `:1635/addresses`
+It happens quite a lot that Bee Clef is installed, but getting the address from bee-clef-keys does not yield the same output as `:1635/addresses`
 
-In this case, the user most likely does not have clef enabled in the configuration of the bee node.
+In this case, the user most likely does not have Bee Clef enabled in the configuration of the bee node.
 
 This doesn't work for you? You get erorr -> `xclip: not found” or “Error: Can’t open display: (null)`
 

--- a/docs/installation/bee-clef.md
+++ b/docs/installation/bee-clef.md
@@ -6,6 +6,10 @@ id: bee-clef
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::info
+Bee Clef is deprecated and is no longer under active development. It is not required for running a Bee node.
+:::
+
 Bee makes use of Go Ethereum's external signer, [Clef](https://geth.ethereum.org/docs/tools/clef/introduction).
 
 Because Bee must sign a lot of transactions automatically and quickly, a [Bee specific version of Clef, Bee Clef](https://github.com/ethersphere/bee-clef) has been packaged which includes all the relevant configuration needed to make Clef work with Bee.

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -5,11 +5,11 @@ id: docker
 
 Docker containers for Bee are hosted at [Docker Hub](https://hub.docker.com/r/ethersphere/bee) for your convenience.
 
-If running a Bee _full node_, it is recommended that you make use of
-Ethereum's external signer, [Clef](/docs/installation/bee-clef). Skip
-ahead if you are comfortable with `docker` basics for instructions on
-how to use [docker-compose](/docs/installation/docker#docker-compose)
-to easily set up Bee with persistent storage and integration with the
+:::info
+Bee-clef is deprecated and is no longer under active development. It is not required for running a Bee node.
+:::
+
+If running a Bee _full node_, the [Bee Clef](/docs/installation/bee-clef) external signer may be used. Skip ahead if you are comfortable with `docker` basics for instructions on how to use [docker-compose](/docs/installation/docker#docker-compose) to easily set up Bee with persistent storage and integration with the
 Bee Clef container.
 
 ### Quick Start

--- a/docs/installation/fund-your-node.md
+++ b/docs/installation/fund-your-node.md
@@ -106,7 +106,11 @@ the wallet file as follows.
 
 ## Debian/Ubuntu Installation
 
-### With Bee-Clef
+### With Bee Clef
+
+:::info
+Bee Clef is deprecated and is no longer under active development. It is not required for running a Bee node.
+:::
 
 Your encrypted wallet file can be found as in this example:
 
@@ -121,7 +125,7 @@ And decrypted using the automatically generated password found at:
 sudo cat /var/lib/bee-clef/password
 ```
 
-### Without Bee-Clef
+### Without Bee Clef
 
 Your key can be found within the `keys/` folder of your datadir. For instance,
 on a normal Ubuntu/Debian install you will find it at:

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -24,8 +24,8 @@ Steps for running a Bee node:
 6.  Check if Bee is working.
 
 :::info
-  We recommend not holding a high value of BZZ or XDAI in your nodes' wallet. Please consider regularly removing accumulated funds. For added security, you may also want to consider running [Bee-Clef](/docs/installation/bee-clef)
-:::
+  Holding a high value of BZZ or XDAI in a node wallet is not recommended. Node operators should consider regularly removing accumulated funds.
+  :::
 
 ## 1. Install Bee
 

--- a/docs/introduction/terminology.md
+++ b/docs/introduction/terminology.md
@@ -68,7 +68,13 @@ Bridged tokens are tokens from one blockchain which have been _bridged_ to anoth
 
 ### BZZ Token
 
-BZZ is Swarm's [ERC-20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) token issued on Ethereum.   
+BZZ is Swarm's [ERC-20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) token issued on Ethereum. It has a [bridged version](terminology#bridged-tokens) on Gnosis Chain with the [xBZZ](terminology#xbzz-token) symbol, and a testnet version on Goerli.   
+
+| Blockchain             | Contract address                                                                                                                       |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Ethereum, BZZ          | [`0x19062190b1925b5b6689d7073fdfc8c2976ef8cb`](https://ethplorer.io/address/0x19062190b1925b5b6689d7073fdfc8c2976ef8cb)                |
+| Gnosis Chain, xBZZ     | [`0xdBF3Ea6F5beE45c02255B2c26a16F300502F68da`](https://blockscout.com/xdai/mainnet/tokens/0xdBF3Ea6F5beE45c02255B2c26a16F300502F68da/) |
+| Goerli (testnet), gBZZ | [`0x2ac3c1d3e24b45c6c310534bc2dd84b5ed576335`](https://goerli.etherscan.io/address/0x2ac3c1d3e24b45c6c310534bc2dd84b5ed576335)    
 
 ### xBZZ Token
 

--- a/docs/working-with-bee/backups.md
+++ b/docs/working-with-bee/backups.md
@@ -70,17 +70,13 @@ Your Bee data directory contains three stores.
 
 ### Keys
 
-The `keys` directory contains your important key material. This is the
+The `keys` directory contains important key material. This is the
 most important data by far, and is produced and retained from Bee's
-initialisation procedure. If you have used **bee-clef** to manage your
-key material and signing procedures, see below for information on how
-to keep backups of your keys.
+initialisation procedure. Bee Clef backup instructions can be found below.
 
 :::info
-If you are using Bee to manage your keys (not recommended - please use [Bee
-Clef](/docs/installation/bee-clef)!). You must convert your keys in order to
-import into MetaMask and other Ethereum wallets. You may use
-[exportSwarmKeys](https://github.com/ethersphere/exportSwarmKey) to make the
+To use Bee keys with MetaMask and other Ethereum wallets they must be converted to a compatible format. 
+[ExportSwarmKeys](https://github.com/ethersphere/exportSwarmKey) can be used to make the
 conversion.
 :::
 

--- a/docs/working-with-bee/uninstalling-bee.md
+++ b/docs/working-with-bee/uninstalling-bee.md
@@ -10,7 +10,7 @@ If you need to remove Bee, you may simply run the below commands.
 ### Ubuntu / Debian / Raspbian
 
 :::danger
-Uninstalling Bee will also delete Bee and Bee-clef data! Make sure you [make backups](/docs/working-with-bee/backups) so you don't lose your keys and data.
+Uninstalling Bee will also delete Bee and Bee Clef data! Make sure you [make backups](/docs/working-with-bee/backups) so you don't lose your keys and data.
 :::
 
 ```bash
@@ -21,7 +21,7 @@ sudo apt-get remove bee-clef
 ### Centos
 
 :::danger
-Uninstalling Bee will also delete Bee and Bee-clef data! Make sure you [make backups](/docs/working-with-bee/backups) so you don't lose your keys and data.
+Uninstalling Bee will also delete Bee and Bee Clef data! Make sure you [make backups](/docs/working-with-bee/backups) so you don't lose your keys and data.
 :::
 
 ```bash
@@ -31,7 +31,7 @@ sudo yum remove bee-clef
 
 ## Data Locations
 
-### Bee-clef
+### Bee Clef
 
 Configuration files are stored in `/etc/bee-clef/`
 

--- a/docs/working-with-bee/upgrade.md
+++ b/docs/working-with-bee/upgrade.md
@@ -13,12 +13,12 @@ properly interact with the swarm.
 ## Upgrade Procedure
 
 :::warning
-Bee sure to [back up](/docs/working-with-bee/backups) your clef key material and [cash out your cheques](/docs/working-with-bee/cashing-out) to make sure your BZZs are safe before applying updates.
+Bee sure to [back up](/docs/working-with-bee/backups) your clef key data and [cash out your cheques](/docs/working-with-bee/cashing-out) to make sure your BZZ are safe before applying updates.
 :::
 
 ### Ubuntu / Debian / Raspbian
 
-To upgrade Bee, simply stop the Bee and Bee-clef services.
+To upgrade Bee, first stop the Bee and Bee Clef services.
 
 ```sh
 sudo systemctl stop bee
@@ -44,7 +44,7 @@ Configuration file '/etc/bee/bee.yaml'
 
 Select `N` to keep your current data and keys.
 
-You may now start your node again, waiting for bee-clef to initialise before starting Bee.
+You may now start your node again by initialising Bee Clef first and then starting Bee.
 
 ```sh
 sudo systemctl start bee-clef


### PR DESCRIPTION
Added contract addresses to BZZ section in terminology so they come up when searching BZZ. Previously they were only in the Fund Your Node section, which isn't an intuitive thing to search for if you want to find the BZZ and xBZZ contract addresses.