### PR TITLE
Adds quotes to target-neighborhood setting

### DIFF
--- a/docs/bee/installation/install.md
+++ b/docs/bee/installation/install.md
@@ -309,7 +309,7 @@ To use this option, it's first necessary to identify potential target neighborho
 
 ```yaml
 ## bee.yaml
-target-neighborhood: 0010100001
+target-neighborhood: "0010100001"
 ```
 
 There is also a [Swarmscan API endpoint](https://api.swarmscan.io/#tag/Network/paths/~1v1~1network~1neighborhoods~1suggestion/get) which you can use to get a suggested neighborhood programmatically:


### PR DESCRIPTION
Without quotes, it would give this error:
Feb 22 12:16:46 VM-a24e52e6-2be7-43d9-9b0e-d30422ac7dea bee[2205]: "time"="2024-02-22 12:16:46.808910" "level"="error" "logger"="node" "msg"="failed to build bee node" "error"="mine overlay address: bad character in binary address"