### PR TITLE
Update instructions on configuring a bee node for Swarm/Sepolia testnet.

### DIFF
--- a/docs/bee/working-with-bee/configuration.md
+++ b/docs/bee/working-with-bee/configuration.md
@@ -380,12 +380,11 @@ You can find the default configurations for your system in the [packaging folder
 
 ## Sepolia Testnet Configuration 
 
-In order to operate a Bee node on the Sepolia testnet, update your configuration to use the options shown in the example below. Make sure that you replace the `blockchain-rpc-endpoint` option value with your own valid Sepolia RPC endpoint. If you choose to use a 3rd party RPC provider like [Infura](https://www.infura.io/), make sure to [check in the docs](https://docs.infura.io/api/network-endpoints) that the endpoint format is up to date, and also make sure that you have filled in your own API key which you can find from the [Infura web app](https://app.infura.io). 
+Connecting to the Swarm testnet is as simple as adding the flag `--mainnet false` to your bee commandline, or `mainnet: false` to your configuration file. Swarm testnet smart contracts are deployed on Sepolia, so if you want to run a light or full node you will need to add a Sepolia RPC to your configuration and fund your node with Sepolia ETH. There are many public faucets you can use to obtain Sepolia ETH, such as [this one from Infura](https://www.infura.io/faucet/sepolia). 
 
-Also make sure to fund your node with Sepolia ETH rather than xDAI to pay for gas on the Sepolia testnet. There are many public faucets you can use to obtain Sepolia ETH, such as [this one from Infura](https://www.infura.io/faucet/sepolia). 
+To get Sepolia BZZ (sBZZ) you can use [this Uniswap market](https://app.uniswap.org/swap?outputCurrency=0x543dDb01Ba47acB11de34891cD86B675F04840db&inputCurrency=ETH); just make sure that you've switched to the Sepolia network in your browser wallet. 
 
-To get Sepolia BZZ (sBZZ) you can use [this Uniswap market](https://app.uniswap.org/swap?outputCurrency=0x543dDb01Ba47acB11de34891cD86B675F04840db&inputCurrency=ETH), just make sure that you've switched to the Sepolia network in your browser wallet. 
-
+Here is an example of a full configuration for a testnet full node:
 
 ```yaml
 data-dir: /home/username/bee/sepolia
@@ -398,5 +397,3 @@ verbosity: 5
 welcome-message: "welcome-from-the-hive"
 warmup-time: 30s
 ```
-
-Here `bootnode` was changed to use the testnet bootnode, `mainnet` has been set to `false`, `network-id` has been changed from the default Swarm network id of 1 to the Swarm testnet id of 10, and `blockchain-rpc-endpoint` has been changed to use an RPC endpoint for the Sepolia testnet rather than Gnosis Chain.


### PR DESCRIPTION
Add clarification that the key configuration option is `mainnet: false`. Remove erroneous final paragraph.