### PR TITLE
fix: correct spelling of "updatable" in introduction.md

### DIFF
--- a/docs/develop/introduction.md
+++ b/docs/develop/introduction.md
@@ -94,7 +94,7 @@ This is the go-to starting point for web3 developers who want to build with Swar
         <a class="hub-card__link" href="/docs/develop/dynamic-content">
           <h3 class="hub-card__title">Dynamic Content</h3>
           <p class="hub-card__desc">
-            Learn how to use feeds to create updateable content on Swarm — with a complete example project that builds a dynamic note board.
+            Learn how to use feeds to create updatable content on Swarm — with a complete example project that builds a dynamic note board.
           </p>
           <span class="hub-card__cta">Open guide</span>
         </a>


### PR DESCRIPTION
## Summary

- Fixes typo: `updateable` → `updatable` in the Dynamic Content card description on the developer hub introduction page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)