### PR TITLE
fix: use python3 in link checker npm scripts

### DIFF
--- a/.link-checker-ignore
+++ b/.link-checker-ignore
@@ -1,0 +1,8 @@
+# URLs to ignore in link checker
+# One URL pattern per line (substring matching, case-sensitive).
+# These URLs are still checked and reported separately, but don't block the check.
+# Lines starting with # are comments.
+
+# Example: remove or update these patterns as needed
+# https://example.com/api
+# example.org/docs

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",
     "precheck:links": "git submodule update --remote tools/docusaurus-link-checker",
-    "check:links": "python tools/docusaurus-link-checker/check_links.py",
-    "build:check": "npm run build && python tools/docusaurus-link-checker/check_links.py"
+    "check:links": "python3 tools/docusaurus-link-checker/check_links.py",
+    "build:check": "npm run build && python3 tools/docusaurus-link-checker/check_links.py"
   },
   "dependencies": {
     "@docsearch/js": "^4.3.2",


### PR DESCRIPTION
## Summary

Fixed npm scripts to use `python3` instead of `python` since the system only has python3 installed. The check_links.py script already specifies the correct shebang.

## Changes

- Updated `package.json` check:links and build:check scripts to use python3
- Created `.link-checker-ignore` file for managing URLs that shouldn't block CI

## Testing

Verified that npm run check:links now executes successfully without python not found errors.