### PR TITLE
docs: add warning about public gateways and batch errors

### DIFF
--- a/docs/develop/tools-and-features/buy-a-stamp-batch.md
+++ b/docs/develop/tools-and-features/buy-a-stamp-batch.md
@@ -13,7 +13,13 @@ import { globalVariables } from '/src/config/globalVariables'
 
 
 
-A postage batch is required to upload data to Swarm. Postage stamp batches represent _right to write_ data on Swarm's [DISC (Distributed Immutable Store of Chunks)](./../../concepts/DISC/DISC.mdx). The parameters which control the duration and quantity of data that can be stored by a postage batch are `depth` and `amount`, with `depth` determining data volume that can be uploaded by the batch and `amount` determining storage duration of data uploaded with the batch. 
+A postage batch is required to upload data to Swarm. Postage stamp batches represent _right to write_ data on Swarm's [DISC (Distributed Immutable Store of Chunks)](./../../concepts/DISC/DISC.mdx). The parameters which control the duration and quantity of data that can be stored by a postage batch are `depth` and `amount`, with `depth` determining data volume that can be uploaded by the batch and `amount` determining storage duration of data uploaded with the batch.
+
+:::warning Public Gateways and Batch Lookup Errors
+If you receive errors like `"get batch ... storage not found"` when using public gateways for uploads, this is expected behavior. **Public gateway endpoints cannot access your postage batches** — batches are stored on your own Bee node and are not shared across the network. 
+
+Always upload using your own Bee node's API endpoint (typically `http://localhost:1633`), not through public gateways. Public gateways can only download content; for uploads, you must connect directly to your node.
+:::
 
 :::info
       The storage volume and duration are both non-deterministic. Volume is non-deterministic due to the details of how [postage stamp batch utilization](./../../concepts/incentives/postage-stamps.md#batch-utilisation) works. While duration is non-deterministic due to price changes made by the [price oracle contract](./../../concepts/incentives/price-oracle.md).


### PR DESCRIPTION
## Summary
Added a warning section to the Postage Stamp Batches documentation explaining:
- Public gateways cannot access user's postage batches (stored only on their own node)
- Why users get 'get batch ... storage not found' errors when trying to upload through public gateways
- Direction to use own node's API endpoint for uploads

## Motivation
Common source of user confusion: attempting to upload through public gateway endpoints and receiving batch lookup errors. This warning prevents that frustration.

## Fixes
Closes #720

## Test plan
- Verify the warning appears prominently in stamp batch documentation
- Confirm the message is clear about why public gateways can't handle uploads with batches