### PR TITLE
fix: add .js extensions to parities imports for strict ESM resolution

### DIFF
--- a/src/components/RedundancyCalc.js
+++ b/src/components/RedundancyCalc.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import parities from './parities';
-import paritiesEncrypted from './paritiesEncrypted';
+import parities from './parities.js';
+import paritiesEncrypted from './paritiesEncrypted.js';
 
 export default function UploadCostCalc() {
   const [errorMessage, setErrorMessage] = useState("");


### PR DESCRIPTION
RedundancyCalc.js imported './parities' and './paritiesEncrypted' without file extensions. Under webpack's fullySpecified ESM resolution (enforced in CI's fresh dependency install), extensionless relative imports fail with "Can't resolve './parities'", breaking the Netlify production build. Add explicit .js extensions so the imports resolve under both strict and loose resolution.