### PR TITLE
fix: remove dead FairOS link and stale Sepolia network entry

### DIFF
--- a/docs/bee/faq.md
+++ b/docs/bee/faq.md
@@ -175,10 +175,3 @@ Network name: Gnosis
 RPC URL: https://xdai.fairdatasociety.org
 Chain ID: 100
 Currency symbol: XDAI
-
-#### Sepolia
-
-Network name: Sepolia test network
-RPC URL: https://sepolia.infura.io/v3/
-Chain ID: 11155111
-Currency symbol: SepoliaETH

--- a/docs/references/fair-data-society.md
+++ b/docs/references/fair-data-society.md
@@ -17,7 +17,6 @@ FDS's software is currently in beta or earlier and has no guarantees of file int
 1. [The Fair Data Protocol (FDP)](https://fdp.fairdatasociety.org/) - A data interoperability protocol for dApps that use personal data.
 1. [Fairdrive](https://fairdrive.fairdatasociety.org/) - Decentralised storage on Swarm.
 1. [Fairdrop](https://fairdrop.fairdatasociety.org/) - An easy and secure way to send your files. No central server. No tracking. No backdoors. 
-1. [FairOS](https://docs.fairos.fairdatasociety.org/docs/) - The operating system for the decentralised web.
 
 ## Links
 


### PR DESCRIPTION
## Summary

Salvages the two still-valid fixes from #794, which is otherwise obsolete and has merge conflicts.

- Remove the dead **FairOS** link (`docs.fairos.fairdatasociety.org`) from the Fair Data Society page
- Remove the stale **Sepolia** network config block from the Bee FAQ

## Why not just merge #794?

The rest of #794 is superseded:
- It targets the **Python link checker**, which was replaced with the TypeScript one in #813 (its branch is `fix/link-checker-python`).
- It edits `docs/references/awesome-list.mdx`, which #811 made **build-time generated and gitignored** — hand-edits get overwritten.
- Its `static/llms.txt` additions were superseded by the llms.txt rework in #802 / #809.

Closing #794 in favor of this focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)