### PR TITLE
ci: open the OpenAPI auto-PR as the bee-worker bot (GHA_PAT_ADVANCED)

### DIFF
--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -4,10 +4,10 @@ name: update openapi
 # openapi/, bumps the Bee version strings in the install docs, and opens (or updates)
 # a PR. Prereleases (-rc*, -beta, v2.7.1a, v2.5.0-v8, ...) are ignored.
 #
-# Requires the BOT_PAT secret (a classic PAT with public_repo scope, or a fine-grained PAT
+# Requires the GHA_PAT_ADVANCED secret (a classic PAT with public_repo scope, or a fine-grained PAT
 # with contents + pull-requests write). It is used so the auto-PR triggers build.yaml CI —
 # PRs opened with the default GITHUB_TOKEN do NOT trigger other workflows. The job fails
-# loudly if BOT_PAT is missing/expired rather than silently skipping CI.
+# loudly if GHA_PAT_ADVANCED is missing/expired rather than silently skipping CI.
 
 on:
   schedule:
@@ -117,7 +117,7 @@ jobs:
         if: ${{ steps.changes.outputs.changed == 'true' }}
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.BOT_PAT }}
+          token: ${{ secrets.GHA_PAT_ADVANCED }}
           branch: bot/update-openapi-${{ steps.resolve.outputs.new_tag }}
           commit-message: "chore: update OpenAPI specs and version refs to Bee ${{ steps.resolve.outputs.new_tag }}"
           title: "Update OpenAPI specs to Bee ${{ steps.resolve.outputs.new_tag }}"


### PR DESCRIPTION
Switches the `update-openapi` workflow's `create-pull-request` token from the personal `BOT_PAT` to the org bot account **bee-worker** via `GHA_PAT_ADVANCED`.

**Why:** the auto-generated OpenAPI update PR is currently opened by a personal account (e.g. #825), so it can't be cleanly reviewed/approved by that same person. With the bot opening it, a maintainer can review + approve.

Already in place:
- `bee-worker` granted write on this repo
- this repo added to the `GHA_PAT_ADVANCED` secret's allow-list

After merge, the now-unused repo `BOT_PAT` secret can be removed and the personal PAT revoked.