### PR TITLE
fix: restore /api/ page visibility under Docusaurus 3.10

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -304,14 +304,17 @@ pre, code, .codeBlockLines_node_modules-\@docusaurus-theme-classic-lib-theme-Cod
 
 /**
 * Prevent redocusaurus from displaying html before its styles are fully
-* loaded. This prevents large icons from being displayed before they 
-* properly styled. 
+* loaded. This prevents large icons from being displayed before they
+* properly styled.
+* Docusaurus sets data-has-hydrated="true" on <html> once client-side
+* hydration completes (the body[data-rh] attribute this hack previously
+* relied on stopped being emitted as of Docusaurus 3.10).
 */
 .redocusaurus {
   display: none;
 }
 
-body[data-rh] .redocusaurus {
+html[data-has-hydrated='true'] .redocusaurus {
   display: block;
 }
 


### PR DESCRIPTION
# What does this PR resolve? 🚀

Fixes the blank **`/api/`** page (Bee API reference) on docs.ethswarm.org.

- Switches the redocusaurus anti-FOUC CSS unlock from `body[data-rh]` to `html[data-has-hydrated='true']`.

**Cause:** The `/api/` page is hidden by design (`.redocusaurus { display: none }`) and revealed once the page hydrates. That reveal rule keyed off the `data-rh` attribute that react-helmet used to stamp on `<body>`. The Docusaurus **3.9.2 → 3.10.1** bump (merged in #822) stopped emitting `data-rh` on the body, so the reveal rule never matched — redoc rendered its full content into the DOM but it stayed `display: none` forever, leaving a blank page. This first shipped to production with the #825 release tag, which is why it looked like #825's fault, but #825 (the OpenAPI v2.8.1 sync) was innocent.

# Details 📝

- `data-has-hydrated="true"` is the attribute Docusaurus 3.10+ officially sets on `<html>` after client-side hydration completes — the correct, supported replacement for the old `body[data-rh]` signal. Same intended behavior (hide until hydrated), durable mechanism.
- No spec, config, or content changes needed; the OpenAPI files are correct.
- The React hydration console warnings (#418/#423) on this page are a pre-existing, unrelated redoc issue ([Redocly/redoc#2734](https://github.com/Redocly/redoc/issues/2734)) — present on working builds too — and are out of scope here.
- Verified with a production build + headless browser: `/api/` renders the full Bee API 8.1.0 reference (menu, operations, samples); homepage unaffected.

# Checklist ✅

- [x] Merged latest `master` and resolved conflicts
- [x] `npm run build` succeeds
- [x] Links checked (`npm run check:links`) where relevant
- [x] `static/llms.txt` updated if pages were added / renamed / deleted
- [x] Content follows [CODING.md](../CODING.md) conventions (`Swarm` vs `swarm`, ..)
- [x] Self-reviewed the diff
- [x] Commits are signed off (`git commit -s`)
