### PR TITLE
docs: clarify full node hardware requirements

### DIFF
--- a/docs/bee/faq.md
+++ b/docs/bee/faq.md
@@ -23,8 +23,8 @@ See the [getting started section](./installation/getting-started.md#requirements
 
 #### Full node
 
-Light and ultra-light nodes run on practically any modern computer, while full nodes have specific hardware and funding requirements.
-See [full node specifications](./working-with-bee/node-types.md#full-node-specifications) for the current list.
+All three node types run on ordinary consumer hardware.
+Full nodes use more disk space and bandwidth than the lighter modes and additionally need a Gnosis Chain connection and funds — see [full node specifications](./working-with-bee/node-types.md#full-node-specifications) for the current list.
 
 ### How much bandwidth is required for each node?
 

--- a/docs/bee/faq.md
+++ b/docs/bee/faq.md
@@ -14,42 +14,37 @@ Depending on your needs you can run an ultra-light, light or full node.
 
 ### What are the differences between Bee node types?
 
-A bee node can be configured to run in various modes based on specific use cases and requirements. [See here](./installation/getting-started.md) for an overview of the differences.
+A bee node can be configured to run in various modes based on specific use cases and requirements.
+[See here](./working-with-bee/node-types.md#node-types-overview) for an overview of the differences.
 
+### What are the requirements for running a Bee node?
 
-#### What are the requirements for running a Bee node?
+See the [getting started section](./installation/getting-started.md#requirements) for more information about running a Bee node.
 
-See the [getting started section](./installation/getting-started.md#software-requirements) for more information about running a Bee node.
+#### Full node
 
-##### Full node
+Light and ultra-light nodes run on practically any modern computer, while full nodes have specific hardware and funding requirements.
+See [full node specifications](./working-with-bee/node-types.md#full-node-specifications) for the current list.
 
-- 20GB -30GB SSD (ideally NVME).
-- 8GB RAM
-- CPU with 2+ cores
-- RPC connection to Gnosis Chain
-- Min 0.1 xDAI for Gnosis GAS fees
-- 1 xBZZ for initial chequebook deployment
-- 10 xBZZ for staking (optional)
-
-##### How much bandwidth is required for each node?
+### How much bandwidth is required for each node?
 
 Typically, each node requires around 10 megabits per second (Mbps) of bandwidth during normal operation.
 
-##### How do I Install Bee on Windows?
+### How do I Install Bee on Windows?
 
 Bee is compatible with Windows and a Bee `.exe` file can be found on the [`releases` page](https://github.com/ethersphere/bee/releases) of the Bee repo.  
 
 It is also possible to [build from the source](./installation/build-from-source.md).
 
-##### How do I get the node's wallet's private key (use-case for Desktop app)?
+### How do I get the node's wallet's private key (use-case for Desktop app)?
 
 See the [backup section](./working-with-bee/backups.md) for more info.
 
-##### How do I import my private key to Metamask?
+### How do I import my private key to Metamask?
 
 You can import the `swarm.key` json file in MetaMask using your password file or the password you have set in your bee config file.
 
-##### Where can I find my password?
+### Where can I find my password?
 
 You can find the password in the root of your data directory. See the [backup section](./working-with-bee/backups.md) for more info.
 

--- a/docs/bee/installation/getting-started.md
+++ b/docs/bee/installation/getting-started.md
@@ -43,16 +43,18 @@ The node type you need to run will differ depending on your use-case:
 
 Refer to the [Node Types](./../working-with-bee/node-types.md) page for deep dive into each node type, their features and limitations, and configuration instructions.
 
-##  Software Requirements
+## Requirements
 
-### Recommended Operating Systems
+###  Software Requirements
+
+#### Recommended Operating Systems
 - Officially supported systems are listed in the [Bee releases](https://github.com/ethersphere/bee/releases).
 - You can [build from source](./build-from-source.md) if your OS is unsupported.
 - **Swarm Desktop users** can use macOS, Windows, or Linux.
 - **Linux/macOS recommended**: Most tools and documentation are designed for Unix-based systems.
 - **Windows users**: While a Window release of Bee is available, you may also consider using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) and using a Linux version of Bee.
 
-### Essential Tools
+#### Essential Tools
 
 While not strictly required, these tools will *greatly* simplify your experience working with Bee nodes:
 
@@ -61,23 +63,20 @@ While not strictly required, these tools will *greatly* simplify your experience
 - **[Swarm CLI](./../working-with-bee/swarm-cli.md)**: Terminal-based Bee node management.
 - **[Bee JS](./../../develop/tools-and-features/bee-js.md)**: JavaScript library for programmatic API access.
 
-## Hardware Requirements
+### Hardware Requirements
 
-### Light and Ultra-Light
+#### Light and Ultra-Light
 
 Light and ultra-light nodes can be run with practically any commercially available modern computer hardware and internet provider, and have very minimal CPU, RAM and network requirements. 
 
-### Full Node
+#### Full Node
 
-Requires significant storage and processing power:
-- **Processor**: Recent 2 GHz dual-core.
-- **RAM**: 8 GB.
-- **Storage**: 30 GB SSD (HDD not recommended).
-- **Internet**: High-speed and stable connection.
+Full nodes require significant storage and processing power, a Gnosis Chain RPC endpoint, and enough xDAI and xBZZ to cover gas fees and chequebook deployment.
+See [full node specifications](./../working-with-bee/node-types.md#full-node-specifications) on the Node Types page for the complete list of hardware and funding requirements.
 
 For staking and storage incentives, test node performance with [`/rchash`](https://docs.ethswarm.org/docs/bee/working-with-bee/bee-api/#rchash).
 
-## Network Requirements
+### Network Requirements
 
 A reliable, high-speed internet connection is recommended when running a full node, while ultra-light and light nodes require less bandwidth. The actual amount of bandwidth consumption depends on the node type and use-case:
 
@@ -85,7 +84,7 @@ A reliable, high-speed internet connection is recommended when running a full no
 - **Light Node**: Moderate usage, based on data transfer volume.
 - **Ultra-Light Node**: Minimal usage, bandwidth utilization restricted based on free-tier download limits.
 
-### RPC Endpoint  
+#### RPC Endpoint  
 
 :::warning
 ***Free public RPC endpoints are discouraged*** since they may enforce rate limiting or may not store the historical smart contract data required by Bee nodes. [Read more](./../working-with-bee/configuration.md#setting-blockchain-rpc-endpoint).
@@ -110,7 +109,7 @@ Without a properly configured RPC endpoint, a Bee node cannot interact with the 
 * Stake tokens
 * Make blockchain transactions
 
-### NAT and Port Forwarding
+#### NAT and Port Forwarding
 
 If running Bee on a home network, there is a good chance it is behind NAT by default. Often simply [enabling port forwarding](https://www.noip.com/support/knowledgebase/general-port-forwarding-guide) will be enough to allow your node to start communicating smoothly with the rest of the network.
 
@@ -140,4 +139,3 @@ If your home network happens to be using [CGNAT (Carrier-Grade NAT)](https://en.
 
 ### [Building from Source](./build-from-source.md)
 - Most flexible, but requires advanced setup.
-

--- a/docs/bee/installation/getting-started.md
+++ b/docs/bee/installation/getting-started.md
@@ -75,7 +75,7 @@ Light and ultra-light nodes have very minimal CPU, RAM, disk and network require
 #### Full Node
 
 Full nodes have modest CPU and RAM requirements too, but they use more disk space and require a more sustained bandwidth than the lighter modes. 
-They also need a Gnosis Chain RPC endpoint and some xDAI and xBZZ to cover gas fees and chequebook deployment.
+They also need a Gnosis Chain RPC endpoint and some xDAI to cover gas fees, including the chequebook deployment transaction.
 See [full node specifications](./../working-with-bee/node-types.md#full-node-specifications) on the Node Types page for the complete list of hardware and funding requirements.
 
 Staking and receiving storage incentives may require more CPU power. 

--- a/docs/bee/installation/getting-started.md
+++ b/docs/bee/installation/getting-started.md
@@ -65,16 +65,21 @@ While not strictly required, these tools will *greatly* simplify your experience
 
 ### Hardware Requirements
 
+All three node types run on ordinary consumer hardware.
+None of them requires a powerful machine.
+
 #### Light and Ultra-Light
 
-Light and ultra-light nodes can be run with practically any commercially available modern computer hardware and internet provider, and have very minimal CPU, RAM and network requirements. 
+Light and ultra-light nodes have very minimal CPU, RAM, disk and network requirements, and run on practically any commercially available computer hardware and internet connection.
 
 #### Full Node
 
-Full nodes require significant storage and processing power, a Gnosis Chain RPC endpoint, and enough xDAI and xBZZ to cover gas fees and chequebook deployment.
+Full nodes have modest CPU and RAM requirements too, but they use more disk space and require a more sustained bandwidth than the lighter modes. 
+They also need a Gnosis Chain RPC endpoint and some xDAI and xBZZ to cover gas fees and chequebook deployment.
 See [full node specifications](./../working-with-bee/node-types.md#full-node-specifications) on the Node Types page for the complete list of hardware and funding requirements.
 
-For staking and storage incentives, test node performance with [`/rchash`](https://docs.ethswarm.org/docs/bee/working-with-bee/bee-api/#rchash).
+Staking and receiving storage incentives may require more CPU power. 
+Test node performance with [`/rchash`](https://docs.ethswarm.org/docs/bee/working-with-bee/bee-api/#rchash) before deciding to participate in the redistribution game.
 
 ### Network Requirements
 

--- a/docs/bee/working-with-bee/bee-api.md
+++ b/docs/bee/working-with-bee/bee-api.md
@@ -3,6 +3,8 @@ title: Bee API
 id: bee-api
 description: Comprehensive reference for Bee's HTTP API endpoints enabling programmatic access to node management uploads downloads and monitoring.
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 The Bee HTTP API is the primary interface to a running Bee node. API-endpoints can be queried using familiar HTTP requests, and will respond with semantically accurate [HTTP status and error codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status) as well as data payloads in [JSON](https://www.json.org/json-en.html) format where appropriate.
 
@@ -478,9 +480,38 @@ If your node is not operating in the correct mode, this can help you to diagnose
 Calling the `/rchash` endpoint triggers the generation of a reserve commitment hash, which is used in the [redistribution game](/docs/concepts/incentives/redistribution-game), and will report the amount of time it took to generate the hash. 
 This is useful for getting a performance benchmark to ensure that your node's processor and disk are fast enough.
 
+<Tabs
+defaultValue="swarm-cli"
+values={[
+{label: 'Swarm CLI', value: 'swarm-cli'},
+{label: 'API', value: 'api'},
+]}>
+<TabItem value="swarm-cli">
+
+The [`swarm-cli`](./swarm-cli.md) command doesn't require arguments.
+It reads the node's overlay address and committed depth, and derives the anchor and depth parameters from them.
+
+```bash
+swarm-cli utility rchash
+```
+
+Pass `--depth` to benchmark against a depth other than the node's current one.
+
+The command gives as a result the time it took to generate the reserve commitment hash. 
+
+```bash
+$ swarm-cli utility rchash
+Reserve sampling duration: 360.37808911 seconds
+```
+
+</TabItem>
+
+<TabItem value="api">
+
 The `/rchash` endpoint has 3 parameters: `depth`, `anchor1`, and `anchor2`.
 For both anchor parameters, use the first 4 hex digits from your node's overlay address (which you can find from the `/addresses` endpoint). 
-For depth, use the current storage depth of your node from the `/status` endpoint (`storageRadius` value):
+For depth, use your node's `committedDepth` from the `/status` endpoint. 
+For nodes which do not use [reserve doubling](./staking.md#reserve-doubling), `committedDepth` is equal to `storageRadius`:
 
 ```text
 /rchash/{depth}/{anchor1}/{anchor2}
@@ -513,6 +544,10 @@ successful result:
   "durationSeconds": 287.52
 }
 ```
+
+</TabItem>
+</Tabs>
+
 
 The `durationSeconds` value should not exceed roughly 6 minutes (360 seconds).
 

--- a/docs/bee/working-with-bee/bee-api.md
+++ b/docs/bee/working-with-bee/bee-api.md
@@ -500,7 +500,6 @@ Pass `--depth` to benchmark against a depth other than the node's current one.
 The command gives as a result the time it took to generate the reserve commitment hash. 
 
 ```bash
-$ swarm-cli utility rchash
 Reserve sampling duration: 360.37808911 seconds
 ```
 
@@ -550,6 +549,13 @@ successful result:
 
 
 The `durationSeconds` value should not exceed roughly 6 minutes (360 seconds).
+
+:::caution A single measurement is not a guarantee
+Sampling time scales with how full the node's reserve is within its radius, since the sampler walks every chunk in radius. 
+Reserve occupancy depends on network conditions rather than on anything the operator sets, so a result measured against a half-full reserve says little about the same node once the reserve fills up. 
+A node holding around 2M chunks can complete a sample in roughly half the time of one at the full default reserve capacity of about 4M chunks. 
+Aim for a comfortable margin below 360 seconds; a marginal pass is not enough.
+:::
 
 :::warning Slow results
 If `durationSeconds` is much longer than 360 seconds (for example, 1191 seconds / ~20 minutes), the node will likely fail to submit proofs in time during the redistribution game, resulting in missed rewards or freezing. 

--- a/docs/bee/working-with-bee/bee-api.md
+++ b/docs/bee/working-with-bee/bee-api.md
@@ -475,15 +475,12 @@ If your node is not operating in the correct mode, this can help you to diagnose
 
 ### _/rchash_
 
-Calling the `/rchash` endpoint triggers the generation of a reserve commitment hash,
-which is used in the [redistribution game](/docs/concepts/incentives/redistribution-game),
-and will report the amount of time it took to generate the hash. This is useful for
-getting a performance benchmark to ensure that your node's hardware is sufficient.
+Calling the `/rchash` endpoint triggers the generation of a reserve commitment hash, which is used in the [redistribution game](/docs/concepts/incentives/redistribution-game), and will report the amount of time it took to generate the hash. 
+This is useful for getting a performance benchmark to ensure that your node's processor is fast enough.
 
 The `/rchash` endpoint has 3 parameters: `depth`, `anchor1`, and `anchor2`.
-For both anchor parameters, use the first 4 hex digits from your node's overlay
-address (which you can find from the `/addresses` endpoint). For depth, use the
-current storage depth of your node from the `/status` endpoint (`storageRadius` value):
+For both anchor parameters, use the first 4 hex digits from your node's overlay address (which you can find from the `/addresses` endpoint). 
+For depth, use the current storage depth of your node from the `/status` endpoint (`storageRadius` value):
 
 ```text
 /rchash/{depth}/{anchor1}/{anchor2}

--- a/docs/bee/working-with-bee/bee-api.md
+++ b/docs/bee/working-with-bee/bee-api.md
@@ -476,7 +476,7 @@ If your node is not operating in the correct mode, this can help you to diagnose
 ### _/rchash_
 
 Calling the `/rchash` endpoint triggers the generation of a reserve commitment hash, which is used in the [redistribution game](/docs/concepts/incentives/redistribution-game), and will report the amount of time it took to generate the hash. 
-This is useful for getting a performance benchmark to ensure that your node's processor is fast enough.
+This is useful for getting a performance benchmark to ensure that your node's processor and disk are fast enough.
 
 The `/rchash` endpoint has 3 parameters: `depth`, `anchor1`, and `anchor2`.
 For both anchor parameters, use the first 4 hex digits from your node's overlay address (which you can find from the `/addresses` endpoint). 
@@ -517,12 +517,9 @@ successful result:
 The `durationSeconds` value should not exceed roughly 6 minutes (360 seconds).
 
 :::warning Slow results
-If `durationSeconds` is much longer than 360 seconds (for example, 1191 seconds /
-~20 minutes), the node will likely fail to submit proofs in time during the
-redistribution game, resulting in missed rewards or freezing. SSD speed and RAM
-are typically the main bottlenecks, since the sampler does heavy random I/O
-across the reserve. Upgrade to a faster SSD first, then consider more RAM or a
-faster processor.
+If `durationSeconds` is much longer than 360 seconds (for example, 1191 seconds / ~20 minutes), the node will likely fail to submit proofs in time during the redistribution game, resulting in missed rewards or freezing. 
+The sampler reads every chunk in radius from local storage, so disk and processor speed are typically the bottlenecks. 
+Upgrade to a faster SSD first, then consider a faster processor or more cores.
 :::
 
 If while running the `/rchash` command there is an evictions related error such

--- a/docs/bee/working-with-bee/node-types.md
+++ b/docs/bee/working-with-bee/node-types.md
@@ -53,10 +53,10 @@ Disk space and sustained bandwidth are the main differences from the lighter nod
 - **Internet**: High-speed and stable connection.
 
 :::info
-Staking raises the CPU demand but not the memory demand.
-Nodes selected for the redistribution game run the sampler process, which is CPU-bound and bandwidth-hungry; 4 cores are sufficient for it.
+Staking means taking part in the redistribution game, which raises CPU demand and disk I/O. 
+This calls for more than 2 processor cores and SSD storage rather than an HDD.
 
-Before staking, test your setup using [the `/rchash` endpoint](./bee-api.md#rchash) in order to confirm your node can complete a sample in time.
+Before staking, test your setup using [the `/rchash` endpoint](./bee-api.md#rchash) to confirm your node can complete a sample in time.
 :::
 
 A full node must also be connected to Gnosis Chain and hold enough funds to cover its on-chain operations:

--- a/docs/bee/working-with-bee/node-types.md
+++ b/docs/bee/working-with-bee/node-types.md
@@ -63,7 +63,6 @@ A full node must also be connected to Gnosis Chain and hold enough funds to cove
 
 - **RPC endpoint**: A connection to Gnosis Chain (see [setting the blockchain RPC endpoint](./configuration.md#setting-blockchain-rpc-endpoint)).
 - **xDAI**: Minimum 0.1 xDAI for Gnosis Chain gas fees.
-- **xBZZ**: 1 xBZZ for the initial chequebook deployment.
 - **(optional) xBZZ for staking**: 10 xBZZ, required only to participate in [storage incentives](./staking.md).
 
 ### Full node configuration

--- a/docs/bee/working-with-bee/node-types.md
+++ b/docs/bee/working-with-bee/node-types.md
@@ -45,10 +45,17 @@ If you intend to participate in the redistribution game to earn storage incentiv
 
 Requires significant storage and processing power compared to other node types:
 
-- **Processor**: Recent 2 GHz dual-core.
-- **RAM**: 8 GB.
-- **Storage**: 30 GB SSD (HDD not recommended).
+- **Processor**: Recent 2 GHz dual-core (2+ cores).
+- **RAM**: 500 MB.
+- **Storage**: 20~30 GB SSD, ideally NVMe (HDD not recommended).
 - **Internet**: High-speed and stable connection.
+
+A full node must also be connected to Gnosis Chain and hold enough funds to cover its on-chain operations:
+
+- **RPC endpoint**: A connection to Gnosis Chain (see [setting the blockchain RPC endpoint](./configuration.md#setting-blockchain-rpc-endpoint)).
+- **xDAI**: Minimum 0.1 xDAI for Gnosis Chain gas fees.
+- **xBZZ**: 1 xBZZ for the initial chequebook deployment.
+- **(optional) xBZZ for staking**: 10 xBZZ, required only to participate in [storage incentives](./staking.md).
 
 ### Full node configuration
 
@@ -146,4 +153,3 @@ Bee will start in ultra-light mode by default, but in order to explicitly config
 - Cannot earn xBZZ by staking xBZZ and participating in the storage incentive system.
 - Cannot earn xBZZ by participating in the bandwidth incentives system.
 - Cannot use PSS or GSOC for sending or receiving.
-

--- a/docs/bee/working-with-bee/node-types.md
+++ b/docs/bee/working-with-bee/node-types.md
@@ -8,7 +8,11 @@ description: Compares full light and ultra-light node types with their features 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Bee nodes can operate in three different modes depending on the user's needs, ranging from full-featured nodes that contribute to the network and earn incentives to lightweight modes that allow for basic interaction with minimal resource requirements. This guide outlines the three primary node types — **_Full_**, **_Light_**, and **_Ultra-Light_** — along with their configurations, capabilities, and limitations.
+Bee nodes can operate in three different modes depending on the user's needs, ranging from full-featured nodes that contribute storage to the network and earn incentives to simpler modes that only download and upload data. 
+This guide outlines the three primary node types — **_Full_**, **_Light_**, and **_Ultra-Light_** — along with their configurations, capabilities, and limitations.
+
+All three modes can run on ordinary consumer computers, without requiring any extraordinary hardware.
+What differs between them is the feature set, how much disk space and bandwidth the node uses, and whether it needs a blockchain connection and funds.
 
 Choosing the right node type depends on your goals, whether it's participating in the Swarm network as a storage provider, developing applications that use Swarm's decentralized storage and messaging, or simply exploring the technology with minimal setup.
 
@@ -30,25 +34,30 @@ Bee can operate in different modes, each tailored to specific use cases:
 
 ## What is a full node? {#full-node}
 
-Full nodes are the most feature-rich nodes in the Swarm network. They provide full upload and download capabilities, store and serve data, and participate in storage and bandwidth incentives. Running a full node requires more system resources, but it allows users to fully engage with and support the network.
+Full nodes are the most feature-rich nodes in the Swarm network. 
+They provide full upload and download capabilities, store and serve data, and participate in storage and bandwidth incentives. 
+A full node uses more disk space and bandwidth than the lighter modes and needs a funded blockchain connection, but its CPU and memory requirements stay low enough for everyday consumer hardware.
 
 Full nodes are ideal for users who want to contribute to the Swarm network and earn incentives, as well as developers who require access to all Bee features including messaging features such as PSS and GSOC.
 
 
 ### Full node specifications
 
-:::warning
-Full nodes require significant system resources, including storage and bandwidth. Additionally, they must be connected to the blockchain to participate in incentives. 
+A full node does not need powerful hardware.
+The requirements below are met by most laptops and desktops, and even single-board computers such as a [Raspberry Pi](https://en.wikipedia.org/wiki/Raspberry_Pi) with an attached SSD.
+Disk space and sustained bandwidth are the main differences from the lighter node types:
 
-If you intend to participate in the redistribution game to earn storage incentives, you should test your setup using [the `/rchash` endpoint](./bee-api.md#rchash) in order to ensure that your hardware is sufficient. Participation in the redistribution game requires a process with high computational and memory requirements, along with significant bandwidth usage.
-:::
-
-Requires significant storage and processing power compared to other node types:
-
-- **Processor**: Recent 2 GHz dual-core (2+ cores).
-- **RAM**: 500 MB.
+- **Processor**: Recent 2 GHz dual-core (2+ cores). 4-cores is comfortable if you intend to take part in the redistribution game.
+- **RAM**: 500 MB. 
 - **Storage**: 20~30 GB SSD, ideally NVMe (HDD not recommended).
 - **Internet**: High-speed and stable connection.
+
+:::info
+Staking raises the CPU demand but not the memory demand.
+Nodes selected for the redistribution game run the sampler process, which is CPU-bound and bandwidth-hungry; 4 cores are sufficient for it.
+
+Before staking, test your setup using [the `/rchash` endpoint](./bee-api.md#rchash) in order to confirm your node can complete a sample in time.
+:::
 
 A full node must also be connected to Gnosis Chain and hold enough funds to cover its on-chain operations:
 
@@ -80,7 +89,7 @@ To run Bee as a full node, set:
 
 Light nodes provide a balance between functionality and resource efficiency. They can upload and download data but do not participate in chunk forwarding or storage for other nodes.
 
-Light nodes are suited for users who want to interact with Swarm without the overhead of running a full node. They can serve the needs of developers who need to access Swarm's download / upload features but do not need advanced messaging features such as PSS and GSOC which are available only in full nodes.
+Light nodes are suited for users who want to interact with Swarm without contributing storage to the network or maintaining a reserve. They can serve the needs of developers who need to access Swarm's download / upload features but do not need advanced messaging features such as PSS and GSOC which are available only in full nodes.
 
 Light node operators cannot earn xBZZ by participating in Swarm's incentives systems, as they do not participate in chunk forwarding or storage but only consume services, paying xBZZ for downloading data from full nodes and buying postage stamp batches for uploading data.
 

--- a/docs/bee/working-with-bee/staking.md
+++ b/docs/bee/working-with-bee/staking.md
@@ -852,8 +852,8 @@ Confirm that `hasSufficientFunds` is `true`, and `isFullySynced` is `true` befor
 One of the most common issues affecting staking is the `sampler` process failing. 
 The sampler is a CPU-intensive process which is run by nodes which are selected to take part in redistribution. 
 It does not need much memory, but on a slow processor or a slow disk it may fail or time out; 4 cores are sufficient. 
-To check a node's performance the `/rchash` endpoint of the API may be used. 
-See the `/rchash` section of the [Bee API page for usage details](./bee-api.md). 
+To check a node's performance, run `swarm-cli utility rchash`, or call the `/rchash` endpoint of the API directly. 
+See the `/rchash` section of the [Bee API page for usage details](./bee-api.md#rchash). 
 
 
 If you are still experiencing problems, you can find more help in the [node-operators](https://discord.gg/kHRyMNpw7t) Discord channel (for your safety, do not accept advice from anyone sending a private message on Discord).

--- a/docs/bee/working-with-bee/staking.md
+++ b/docs/bee/working-with-bee/staking.md
@@ -851,7 +851,7 @@ Confirm that `hasSufficientFunds` is `true`, and `isFullySynced` is `true` befor
 
 One of the most common issues affecting staking is the `sampler` process failing. 
 The sampler is a CPU-intensive process which is run by nodes which are selected to take part in redistribution. 
-It does not need much memory, but on a slow processor it may fail or time out; 4 cores are sufficient. 
+It does not need much memory, but on a slow processor or a slow disk it may fail or time out; 4 cores are sufficient. 
 To check a node's performance the `/rchash` endpoint of the API may be used. 
 See the `/rchash` section of the [Bee API page for usage details](./bee-api.md). 
 

--- a/docs/bee/working-with-bee/staking.md
+++ b/docs/bee/working-with-bee/staking.md
@@ -849,7 +849,11 @@ Confirm that `hasSufficientFunds` is `true`, and `isFullySynced` is `true` befor
 
 #### Run sampler process to benchmark performance
 
-One of the most common issues affecting staking is the `sampler` process failing. The sampler is a resource intensive process which is run by nodes which are selected to take part in redistribution. The process may fail or time out if the node's hardware specifications aren't high enough. To check a node's performance the `/rchash` endpoint of the API may be used. See the `/rchash` section of the [Bee API page for usage details](./bee-api.md). 
+One of the most common issues affecting staking is the `sampler` process failing. 
+The sampler is a CPU-intensive process which is run by nodes which are selected to take part in redistribution. 
+It does not need much memory, but on a slow processor it may fail or time out; 4 cores are sufficient. 
+To check a node's performance the `/rchash` endpoint of the API may be used. 
+See the `/rchash` section of the [Bee API page for usage details](./bee-api.md). 
 
 
 If you are still experiencing problems, you can find more help in the [node-operators](https://discord.gg/kHRyMNpw7t) Discord channel (for your safety, do not accept advice from anyone sending a private message on Discord).


### PR DESCRIPTION
# What does this PR resolve? 🚀

Corrects the documented full node hardware requirements and removes framing that made running a full node sound more demanding than it is.

- **Fixes the RAM figure**: full nodes were documented as needing **8 GB**; the actual ceiling is **500 MB**, including while playing the redistribution game. The wrong figure appeared in three separate places.
- **Makes `node-types.md` the single source of truth** for full node requirements. `getting-started.md` and `faq.md` now link to `#full-node-specifications` instead of carrying their own drifting copies.
- **Corrects the staking resource claim**: the sampler was documented as having "high computational and memory requirements". It is CPU-bound, not memory-bound — 4 cores are sufficient.
- **Reframes the hardware bar** across five pages: all three node types run on ordinary consumer hardware. The real differences for a full node are disk space, sustained bandwidth, and a funded blockchain connection.

# Details 📝

The three copies of the full node spec had drifted apart (30 GB SSD vs. 20–30 GB NVMe), and the FAQ copy was the only one listing the on-chain funding requirements. Both lists are now merged into `node-types.md` under two groups — hardware, and blockchain/funding — so nothing was dropped in consolidation.

The `:::warning` above the full node spec list became an `:::info` placed *below* it. It previously primed readers to expect heavy requirements before showing them numbers that are anything but; it is guidance about staking, not a hazard.

Wording changes that followed from the corrected numbers:

- `staking.md` — "resource intensive" → "CPU-intensive", with the 4-core figure and an explicit note that memory is not the constraint.
- `bee-api.md` — `/rchash` benchmarks "your node's processor is fast enough" rather than "hardware is sufficient", since CPU is what it measures.
- `node-types.md` — dropped "requires more system resources" and "without the overhead of running a full node".
- Vague phrasing like "practically any modern computer" replaced with the concrete specs plus a reference point (laptops, desktops, or a Raspberry Pi with an attached SSD).

`getting-started.md` also gains a `## Requirements` parent heading, with software/hardware/network demoted beneath it — the FAQ's `#requirements` anchor now points there. Some headings in `faq.md` were promoted from `#####` to `###`, which had been nested under a question rather than under a section.

No pages were added, renamed, or deleted.

## Verification

`npm run build:check` passes: **0 broken internal links**, 0 broken links in the built HTML (7,731 checked), 0 external 404s. The new `#full-node-specifications`, `#requirements` and `#node-types-overview` anchors were confirmed present in the build output, and all inbound links to them resolve.

The link checker also reports 16 stale external redirects, 7 unverifiable URLs and 6 llms.txt gaps. All are pre-existing on `master` and unrelated to these lines, so they are deliberately left for a separate link-maintenance PR.

# Checklist ✅

- [x] Merged latest `master` and resolved conflicts
- [x] `npm run build` succeeds
- [x] Links checked (`npm run check:links`) where relevant
- [x] `static/llms.txt` updated if pages were added / renamed / deleted
- [x] Content follows CODING.md conventions (`Swarm` vs `swarm`, ..)
- [x] Self-reviewed the diff
- [x] Commits are signed off (`git commit -s`)
