### PR TITLE
Publish SwarmCommon.yaml so the served OpenAPI spec can be dereferenced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ resources
 .netlify
 /src/pages/awesome-swarm.mdx
 /static/openapi.yaml
+/static/SwarmCommon.yaml
+/static/.well-known/agent.json
 /static/cheatsheets
 test
 docs/references/awesome-list.mdx

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "prebuild": "node -e \"require('fs').copyFileSync('openapi/Swarm.yaml', 'static/openapi.yaml')\" && node scripts/fetch-awesome-swarm.mjs && node scripts/fetch-cheatsheets.mjs && node scripts/validate-llms-txt.mjs",
+    "prebuild": "node -e \"const f=require('fs');f.copyFileSync('openapi/Swarm.yaml','static/openapi.yaml');f.copyFileSync('openapi/SwarmCommon.yaml','static/SwarmCommon.yaml');f.copyFileSync('static/.well-known/agent-card.json','static/.well-known/agent.json')\" && node scripts/fetch-awesome-swarm.mjs && node scripts/fetch-cheatsheets.mjs && node scripts/validate-llms-txt.mjs && node scripts/validate-openapi-spec.mjs",
     "build": "docusaurus build",
     "build:quiet": "cross-env NODE_OPTIONS=\"--disable-warning=DEP0040 --disable-warning=DEP0169\" docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/scripts/validate-openapi-spec.mjs
+++ b/scripts/validate-openapi-spec.mjs
@@ -1,0 +1,113 @@
+// Validate the OpenAPI spec published to static/ — the file agents actually fetch
+// from https://docs.ethswarm.org/openapi.yaml.
+//
+// Why this exists: Swarm.yaml keeps every schema, parameter, header and response
+// in a sibling file (SwarmCommon.yaml) and references it with relative $refs. The
+// Redoc page at /api/ dereferences those at build time from the openapi/ directory,
+// so it renders correctly even when the *published* file cannot be dereferenced at
+// all. That failure is invisible over HTTP — the spec still returns 200 — so only a
+// build-time check catches it.
+//
+// Exits 1 on an unresolvable $ref. Unlike validate-llms-txt.mjs this blocks the
+// build, because a spec that no OpenAPI client can dereference is broken output,
+// not a documentation warning.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname, resolve as resolvePath } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const SPEC = join(ROOT, 'static', 'openapi.yaml');
+
+const docCache = new Map();
+
+/** Load and parse a YAML document, memoised by absolute path. */
+function loadDoc(absPath) {
+  if (!docCache.has(absPath)) {
+    if (!existsSync(absPath)) {
+      docCache.set(absPath, null);
+    } else {
+      docCache.set(absPath, parse(readFileSync(absPath, 'utf8')));
+    }
+  }
+  return docCache.get(absPath);
+}
+
+/** Walk a JSON Pointer (RFC 6901) into a parsed document. */
+function resolvePointer(doc, pointer) {
+  let node = doc;
+  for (const rawPart of pointer.replace(/^#\/?/, '').split('/')) {
+    if (rawPart === '') continue;
+    const part = rawPart.replace(/~1/g, '/').replace(/~0/g, '~');
+    if (node && typeof node === 'object' && part in node) {
+      node = node[part];
+    } else {
+      return undefined;
+    }
+  }
+  return node;
+}
+
+/** Collect every $ref value in a document, with the path where it was found. */
+function collectRefs(node, trail = '', found = []) {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => collectRefs(item, `${trail}/${i}`, found));
+  } else if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node)) {
+      if (key === '$ref' && typeof value === 'string') {
+        found.push({ ref: value, at: trail || '/' });
+      } else {
+        collectRefs(value, `${trail}/${key}`, found);
+      }
+    }
+  }
+  return found;
+}
+
+if (!existsSync(SPEC)) {
+  console.error(`✗ ${SPEC} not found — the prebuild copy step did not run.`);
+  process.exit(1);
+}
+
+const spec = loadDoc(SPEC);
+const refs = collectRefs(spec);
+const failures = [];
+const externalFiles = new Set();
+
+for (const { ref, at } of refs) {
+  const [filePart, pointer = ''] = ref.split('#');
+  // A ref with no file part is internal to this document.
+  const targetPath = filePart ? resolvePath(dirname(SPEC), filePart) : SPEC;
+  if (filePart) externalFiles.add(filePart);
+
+  const targetDoc = loadDoc(targetPath);
+  if (targetDoc === null) {
+    failures.push(`${ref}  (referenced at ${at}) — file not published alongside the spec`);
+    continue;
+  }
+  if (pointer && resolvePointer(targetDoc, pointer) === undefined) {
+    failures.push(`${ref}  (referenced at ${at}) — pointer does not resolve`);
+  }
+}
+
+const distinct = new Set(refs.map((r) => r.ref));
+console.log(
+  `OpenAPI spec check: ${refs.length} $refs (${distinct.size} distinct) across ` +
+    `${externalFiles.size} external file(s): ${[...externalFiles].join(', ') || 'none'}`
+);
+
+if (failures.length) {
+  const unique = [...new Set(failures)];
+  console.error(`\n✗ ${failures.length} unresolvable $ref(s), ${unique.length} distinct:\n`);
+  for (const f of unique.slice(0, 20)) console.error(`   ${f}`);
+  if (unique.length > 20) console.error(`   … and ${unique.length - 20} more`);
+  console.error(
+    `\nEvery file referenced by static/openapi.yaml must be copied into static/ ` +
+      `by the prebuild step, or the published spec cannot be dereferenced.`
+  );
+  process.exit(1);
+}
+
+console.log('✓ All $refs resolve in the published spec.');


### PR DESCRIPTION
`https://docs.ethswarm.org/openapi.yaml` returns HTTP 200 but cannot be dereferenced by any OpenAPI client. This makes it usable.

## Why

The prebuild step copies `openapi/Swarm.yaml` → `static/openapi.yaml`, but not its sibling `openapi/SwarmCommon.yaml`, which holds **99 schemas, 23 parameters, 7 headers and 8 responses**. All **446 `$ref`s** in the published spec point at that one file, and it is not published, so every one of them dangles.

What that means in practice for anyone pointing a tool at the URL:

| Tool | Today | After |
|---|---|---|
| `openapi-generator` / `swagger-codegen` | fails, or emits endpoints with no types | generates a working Bee client in any of ~50 languages |
| Postman / Insomnia import | endpoints appear with no parameters, bodies or schemas | full import |
| Swagger UI / Redocly pointed at the URL | will not render | renders |
| Agent framework binding tools from a spec | endpoints with no parameter definitions | usable tool definitions |

The consequence worth caring about is not "the file is malformed" but that the spec never states `swarm-postage-batch-id` is a required header. Someone generating a client gets code that compiles, calls the API, and receives a 400 with no indication why.

**The Redoc page at `/api/` is unaffected**, which is why this went unnoticed: redocusaurus resolves the refs at build time from the `openapi/` directory where both files sit together. The human page renders correctly while the published file — the one machines fetch — is broken and still returns 200.

## What changed

1. **`package.json`** — the prebuild copy step also publishes `SwarmCommon.yaml`, and `.well-known/agent.json` as a copy of `agent-card.json` so clients probing the spec-canonical A2A filename find the card instead of a 404.
2. **`.gitignore`** — both new outputs are generated, not committed, so `openapi/` and `agent-card.json` remain the single sources of truth and cannot drift.
3. **`scripts/validate-openapi-spec.mjs`** (new) — resolves every `$ref` in the published spec and **exits non-zero** if any fails. Deliberately stricter than `validate-llms-txt.mjs`, which is warning-only: a spec no client can dereference is broken output rather than a documentation warning. Without this the regression returns silently, since the broken file still serves 200.

All refs resolve because they are bare relative references (`SwarmCommon.yaml#/…`) and both files land at the site root.

## Verified both directions

| Run | Result |
|---|---|
| Copy only `Swarm.yaml` (current behaviour) | **exit 1** — 446 unresolvable refs, each listed with its location |
| New prebuild copy step | **exit 0** — all `$ref`s resolve |

Outputs: `openapi.yaml` 87,639 b, `SwarmCommon.yaml` 37,475 b, `agent.json` byte-identical to `agent-card.json`.

## Caveats

- **I have not measured how many people or tools actually fetch this spec, and I cannot.** So I cannot claim a number of users unblocked. What is certain is that the endpoint is broken today, the fix is two lines plus a test, and it costs nothing at build time — so while the audience is unknown, publishing a spec that works cannot hurt.
- **`/openapi.json` is deliberately not included.** Under this approach it would be a JSON file whose refs still point into a `.yaml`, which needs ref-rewriting — effectively bundling. Better handled by a `@redocly/cli bundle` step later; tracked in ethersphere/DevRel#904.
- A full `docusaurus build` was not run locally (it needs network for the awesome-swarm and cheatsheet fetches). The validator was exercised directly against both states instead. Worth watching CI, since this PR adds a step that can fail the build.

Addresses ethersphere/DevRel#904.

*Description generated with help of AI.*
